### PR TITLE
Configured artist boost for composers

### DIFF
--- a/artist/conf/solrconfig.xml
+++ b/artist/conf/solrconfig.xml
@@ -19,7 +19,28 @@
     <xi:include href="common/autoCommit.xml" />
     <xi:include href="common/autoSoftCommit.xml" />
   </updateHandler>
-  <xi:include href="common/requestHandler-select.xml" />
+  <!-- xi:include href="common/requestHandler-select.xml" / -->
+  <requestHandler name="/select" class="solr.SearchHandler" >
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <int name="rows">10</int>
+      <str name="fl">score</str>
+      <str name="defType">edismax</str>
+      <str name="bq">mbid:24f1766e-9635-4d58-a4d4-9413f9f98a4c^2</str> <!-- Bach -->
+      <str name="bq">mbid:1f9df192-a621-4f54-8850-2c5373b7eac9^2</str> <!-- Beethoven -->
+      <str name="bq">mbid:c70d12a2-24fe-4f83-a6e6-57d84f8efb51^2</str> <!-- Brahms -->
+      <str name="bq">mbid:4e60a56a-514a-4a19-a3cc-49927c96b3cb^2</str> <!-- Elgar -->
+      <str name="bq">mbid:27870d47-bb98-42d1-bf2b-c7e972e6befc^2</str> <!-- Handel -->
+      <str name="bq">mbid:c130b0fb-5dce-449d-9f40-1437f889f7fe^2</str> <!-- Haydn, Joseph -->
+      <str name="bq">mbid:b972f589-fb0e-474e-b64a-803b0364fa75^2</str> <!-- Mozart -->
+      <str name="bq">mbid:f91e3a88-24ee-4563-8963-fab73d2765ed^2</str> <!-- Schubert -->
+      <str name="bq">mbid:8255db36-4902-4cf6-8612-0f2b4288bc9a^2</str> <!-- Strauss, Johann -->
+      <str name="bq">mbid:4cb43d82-824e-4034-b03d-1a98f36f6e16^2</str> <!-- Strauss, Richard -->
+      <str name="bq">mbid:f1bedf1f-4445-4651-9c35-f4a3f3860a13^2</str> <!-- Verdi -->
+      <str name="bq">mbid:ad79836d-9849-44df-8789-180bbc823f3c^2</str> <!-- Vivaldi -->
+      <str name="bq">mbid:eefd7c1e-abcf-4ccc-ba60-0fd435c9061f^2</str> <!-- Wagner -->
+    </lst>
+   </requestHandler>
   <xi:include href="common/requestHandler-get.xml" />
   <xi:include href="common/requestHandler-replication.xml" />
   <xi:include href="common/requestDispatcher.xml" />


### PR DESCRIPTION
Double the score for documents that do not have their common name as their artist name. This is a common problem for classical composers who are often just known by their last name but have their full name stored in the artist field meaning that a search for them by just their last name often favours other artist who have the same lastName but none/less firstNames.
